### PR TITLE
Replace obscure Unicode character with standard ASCII key

### DIFF
--- a/morphometrix/__main__.py
+++ b/morphometrix/__main__.py
@@ -462,7 +462,7 @@ class MainWindow(QMainWindow):
                     writer.writerows(line)
 
                 writer.writerow([''])
-                writer.writerow(['Object'] + ['Area (m\u00B2)'])
+                writer.writerow(['Object'] + ['Area (m2)'])
 
                 for k, f in enumerate(self.areaNames):  #write areas
                     line = [[f] + ["{0:.3f}".format(areas[k])]]  #need to convert NaNs to empty


### PR DESCRIPTION
The csv output of morphometrix is used by downstream packages, e.g. https://github.com/cbirdferrer/collatrix. Using the "m\u00B2" unicode characters prevents users from loading the output csvs in pandas DFs, etc. Using m2 to represent meters squared instead of m\u00B2 is less error prone. Thanks!